### PR TITLE
Add fav only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ refresh_token: {REFRESH TOKEN}
 | TWITTER_USER_IDS            | Twitter user ID to crawling.If multiple users are specified, separate them with `,`                             | ✓       |
 | INTERVAL                    | Crawler interval(minutes). default=`5` minutes                                                                  |         |
 | MODE_SPECIFIED              | Specifies Crawler mode. `rt`, `fav`, `mixed`. default=`rt`                                                      |         |
-| TWEET_COUNT                 | Specifies the number of tweet statuses to retrieve. default=`100`                                               |         |
+| TWEET_COUNT                 | Specifies the number of tweet statuses to retrieve. default=`200`                                               |         |
 | TWEET_PAGES                 | Specifies the page of results to retrieve. default=`5`                                                          |         |
 | DATABASE_URL                | Database url. format `postgres://<username>:<password>@<hostname>:<port>/<database>`                            | ✓       |
 | DATABASE_SSLMODE            | [Database sslmode.](https://gist.github.com/pfigue/3440e2bc986550a6b8ec#valid-sslmode-values) default=`require` |         |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ refresh_token: {REFRESH TOKEN}
 | INTERVAL                    | Crawler interval(minutes). default=`5` minutes                                                                  |         |
 | MODE_SPECIFIED              | Specifies Crawler mode. `rt`, `fav`, `mixed`. default=`rt`                                                      |         |
 | TWEET_COUNT                 | Specifies the number of tweet statuses to retrieve. default=`200`                                               |         |
-| TWEET_PAGES                 | Specifies the page of results to retrieve. default=`5`                                                          |         |
+| TWEET_PAGES                 | Specifies the page of results to retrieve. default=`25`                                                          |         |
 | DATABASE_URL                | Database url. format `postgres://<username>:<password>@<hostname>:<port>/<database>`                            | ✓       |
 | DATABASE_SSLMODE            | [Database sslmode.](https://gist.github.com/pfigue/3440e2bc986550a6b8ec#valid-sslmode-values) default=`require` |         |
 | TZ                          | Time zone                                                                                                       |         |

--- a/app/twitter.py
+++ b/app/twitter.py
@@ -181,6 +181,23 @@ class Twitter:
                 else:
                     print('no media')
 
+    def get_favorite_media(self, user: str):
+        for tweets in self.limit_handled(tweepy.Cursor(self.api.favorites,
+                                                       id=user.id,
+                                                       count=self.tweet_count,
+                                                       tweet_mode="extended").pages(self.tweet_page)):
+            media_tweet_dicts = {}
+            for tweet in tweets:
+                try:
+                    media_tweet_dict = self.get_media_tweets(tweet)
+                except:
+                    traceback.print_exc()
+
+                if media_tweet_dict:
+                    media_tweet_dicts.update(media_tweet_dict)
+
+        return media_tweet_dicts
+
     def show_rt_media(self, user):
         for tweets in self.limit_handled(tweepy.Cursor(self.api.user_timeline,
                                                        id=user.id,
@@ -237,7 +254,7 @@ class Twitter:
     def get_target_tweets(self, user):
         target_tweets_dict = {}
         if 'fav' in self.mode:
-            # TODO: add process for fav only
+            target_tweets_dict.update(self.get_favorite_media(user))
             pass
         if 'rt' in self.mode or 'mixed' in self.mode:
             target_tweets_dict.update(self.get_rt_media(user))

--- a/app/twitter.py
+++ b/app/twitter.py
@@ -14,7 +14,7 @@ from app.instagram import Instagram
 class Twitter:
     def __init__(self):
         self.tweet_page = int(Env.get_environment('TWEET_PAGES', default='5'))
-        self.tweet_count = int(Env.get_environment('TWEET_COUNT', default='100'))
+        self.tweet_count = int(Env.get_environment('TWEET_COUNT', default='200'))
         self.mode = Env.get_environment('MODE_SPECIFIED', default='rt')
 
         consumer_key = Env.get_environment('TWITTER_CONSUMER_KEY', required=True)

--- a/app/twitter.py
+++ b/app/twitter.py
@@ -187,8 +187,8 @@ class Twitter:
                                                        id=user.id,
                                                        count=self.tweet_count,
                                                        tweet_mode="extended").pages(self.tweet_page)):
-            media_tweet_dict = None
             for tweet in tweets:
+                media_tweet_dict = None
                 try:
                     media_tweet_dict = self.get_media_tweets(tweet)
                 except:

--- a/app/twitter.py
+++ b/app/twitter.py
@@ -13,7 +13,7 @@ from app.instagram import Instagram
 
 class Twitter:
     def __init__(self):
-        self.tweet_page = int(Env.get_environment('TWEET_PAGES', default='5'))
+        self.tweet_page = int(Env.get_environment('TWEET_PAGES', default='25'))
         self.tweet_count = int(Env.get_environment('TWEET_COUNT', default='200'))
         self.mode = Env.get_environment('MODE_SPECIFIED', default='rt')
 

--- a/app/twitter.py
+++ b/app/twitter.py
@@ -182,11 +182,12 @@ class Twitter:
                     print('no media')
 
     def get_favorite_media(self, user: str):
+        media_tweet_dicts = {}
         for tweets in self.limit_handled(tweepy.Cursor(self.api.favorites,
                                                        id=user.id,
                                                        count=self.tweet_count,
                                                        tweet_mode="extended").pages(self.tweet_page)):
-            media_tweet_dicts = {}
+            media_tweet_dict = None
             for tweet in tweets:
                 try:
                     media_tweet_dict = self.get_media_tweets(tweet)
@@ -255,7 +256,6 @@ class Twitter:
         target_tweets_dict = {}
         if 'fav' in self.mode:
             target_tweets_dict.update(self.get_favorite_media(user))
-            pass
         if 'rt' in self.mode or 'mixed' in self.mode:
             target_tweets_dict.update(self.get_rt_media(user))
         return target_tweets_dict


### PR DESCRIPTION
modeにfavが指定されていた場合の処理を追加しました。

favはユーザがfavした順番が取れないため、twitter公式APIの制限ギリギリまで取得して保存処理を回す実装にしました。