### PR TITLE
fix #12 open()をリトライ処理の中で実行するように変更

### DIFF
--- a/app/google_photos.py
+++ b/app/google_photos.py
@@ -69,7 +69,6 @@ class GooglePhotos:
     @retry((GoogleApiResponseNG, ConnectionAbortedError, TimeoutError), tries=3, delay=2, backoff=2)
     def _execute_upload_api(self, file_path):
         with open(file_path, 'rb') as file_data:
-            print(f'data={file_data}, upload_file_name={os.path.basename(file_path)}')
             headers = {
                 'Authorization': 'Bearer ' + self.credentials.token,
                 'Content-Type': 'application/octet-stream',

--- a/app/google_photos.py
+++ b/app/google_photos.py
@@ -67,22 +67,24 @@ class GooglePhotos:
         return status
 
     @retry((GoogleApiResponseNG, ConnectionAbortedError, TimeoutError), tries=3, delay=2, backoff=2)
-    def _execute_upload_api(self, data, upload_file_name):
-        headers = {
-            'Authorization': 'Bearer ' + self.credentials.token,
-            'Content-Type': 'application/octet-stream',
-            'X-Goog-Upload-File-Name': upload_file_name,
-            'X-Goog-Upload-Protocol': 'raw',
-        }
-        (response, upload_token) = self.authorized_http.request(uri=UPLOAD_API_URL, method='POST', body=data,
-                                                                headers=headers)
+    def _execute_upload_api(self, file_path):
+        with open(file_path, 'rb') as file_data:
+            print(f'data={file_data}, upload_file_name={os.path.basename(file_path)}')
+            headers = {
+                'Authorization': 'Bearer ' + self.credentials.token,
+                'Content-Type': 'application/octet-stream',
+                'X-Goog-Upload-File-Name': os.path.basename(file_path),
+                'X-Goog-Upload-Protocol': 'raw',
+            }
+            (response, upload_token) = self.authorized_http.request(uri=UPLOAD_API_URL, method='POST', body=file_data,
+                                                                    headers=headers)
+
         if response.status != 200:
-            raise GoogleApiResponseNG(f'Google API response NG, content={upload_token}')
+            raise GoogleApiResponseNG(f'Google API response NG, status={response.status}, content={upload_token}')
         return upload_token.decode('utf-8')
 
     def upload_media(self, file_path, description):
-        with open(file_path, 'rb') as file_data:
-            upload_token = self._execute_upload_api(data=file_data, upload_file_name=os.path.basename(file_path))
+        upload_token = self._execute_upload_api(file_path=file_path)
 
         new_item = {
             'newMediaItems': [{


### PR DESCRIPTION
`Payload must not be empty` エラーが出ていたため
リトライ処理の外で発行していたopen()をリトライ処理の中で実行するように変更しました。
少なくともエラーが発生する確率は下げられるはずです。