### PR TITLE
Fix #17 #26 ConnectionError時にリトライするように変更

### DIFF
--- a/app/google_photos.py
+++ b/app/google_photos.py
@@ -66,7 +66,7 @@ class GooglePhotos:
         status = response['newMediaItemResults'][0]['status']
         return status
 
-    @retry((GoogleApiResponseNG, ConnectionAbortedError, TimeoutError), tries=3, delay=2, backoff=2)
+    @retry((GoogleApiResponseNG, ConnectionError, TimeoutError), tries=3, delay=2, backoff=2)
     def _execute_upload_api(self, file_path):
         with open(file_path, 'rb') as file_data:
             headers = {


### PR DESCRIPTION
#26 で発生していた `BrokenPipeError`
#17 で発生していた `ConnectionResetError`
の親クラスである `ConnectionError` を指定してエラーの場合リトライするように変更しました。
これによってある程度エラーを緩和できると思われます。

```
      |    +-- ConnectionError
      |    |    +-- BrokenPipeError
      |    |    +-- ConnectionAbortedError
      |    |    +-- ConnectionRefusedError
      |    |    +-- ConnectionResetError
```