### PR TITLE
誤ってGoogle Photosに2重登録されないように変更

### DIFF
--- a/app/twitter.py
+++ b/app/twitter.py
@@ -119,7 +119,7 @@ class Twitter:
         media_tweet_dict = {}
 
         tweet_status = tweet
-        if tweet.retweeted and hasattr(tweet, 'retweeted_status'):
+        if hasattr(tweet, 'retweeted_status'):
             tweet_status = tweet.retweeted_status
 
         if self.is_quoted(tweet_status) and hasattr(tweet_status, 'quoted_status'):


### PR DESCRIPTION
RTしていてもある程度時間がたつとなぜかtweet_statusの `retweeted` がfalseになるため
 'retweeted_status' の方をみないようになる。
そうなると、tweet_idはRTしたツイートのtweet_idではなく自分のツイートのtweet_idになり、
自分のtweet_idはまだDBに登録されてないので、ツイート元は既にDBにもGoogle Photosにも登録されているが誤ってGoogle Photosに2重登録される場合がある。

そのため  `retweeted` を見るのをやめて `retweeted_status` があれば  `retweeted_status` を見るように変更する。