### PR TITLE
Fix #22 バックアップに失敗したメディアファイルを救済する処理を追加

### DIFF
--- a/app/crawler.py
+++ b/app/crawler.py
@@ -10,6 +10,7 @@ import urllib.error
 
 from googleapiclient.errors import HttpError
 from retry import retry
+from typing import List, Tuple
 
 from app.env import Env
 from app.google_photos import GooglePhotos
@@ -51,6 +52,30 @@ class Crawler:
         url = re.sub(r'\?.*$', '', url)
         return f'{self._download_dir}/{os.path.basename(url)}'
 
+    def save_media(self, url: str, description: str) -> bool:
+        # download
+        download_path: str = self.make_download_path(url)
+        if url.startswith('https://pbs.twimg.com/media') or url.startswith('http://pbs.twimg.com/media'):
+            url = self.twitter.make_original_image_url(url)
+        try:
+            self.download_media(url, download_path)
+        except urllib.error.HTTPError:
+            traceback.print_exc()
+            print(f'download failed. media_url={url}', file=sys.stderr)
+            return False
+
+        # upload
+        is_uploaded: bool = self.upload_google_photos(download_path, description)
+
+        # delete
+        os.remove(download_path)
+
+        if not is_uploaded:
+            print(f'upload failed. media_url={url}', file=sys.stderr)
+            return False
+
+        return True
+
     def backup_media(self, media_tweet_dicts):
         if not media_tweet_dicts:
             return
@@ -59,28 +84,15 @@ class Crawler:
         for tweet_id, in target_tweet_ids:
             tweet_status_media_dict = media_tweet_dicts[tweet_id]
             tweet_status = tweet_status_media_dict['tweet_status']
+            failed_upload_medias: List[Tuple[str, str]] = []
 
             Twitter.show_media_info(tweet_status_media_dict)
             for url in tweet_status_media_dict['urls']:
-                # download
-                download_path = self.make_download_path(url)
-                if url.startswith('https://pbs.twimg.com/media') or url.startswith('http://pbs.twimg.com/media'):
-                    url = self.twitter.make_original_image_url(url)
-                try:
-                    Crawler.download_media(url, download_path)
-                except urllib.error.HTTPError:
-                    traceback.print_exc()
-                    print(f'download failed. tweet_id={tweet_id}, media_url={url}', file=sys.stderr)
-                    continue
-
-                # upload
-                is_uploaded = self.upload_google_photos(download_path, Twitter.make_tweet_description(tweet_status))
-
-                # delete
-                os.remove(download_path)
-
-                if not is_uploaded:
-                    print(f'upload failed. tweet_id={tweet_id}, media_url={url}', file=sys.stderr)
+                description: str = Twitter.make_tweet_description(tweet_status)
+                is_saved: bool = self.save_media(url, description)
+                if not is_saved:
+                    failed_upload_medias.append((url, description))
+                    print(f'Save failed. tweet_id={tweet_id}, media_url={url}', file=sys.stderr)
                     continue
 
             # store update
@@ -90,9 +102,35 @@ class Crawler:
                 print(f'Insert failed. tweet_id={tweet_id}', e.args, file=sys.stderr)
                 traceback.print_exc()
 
+            if not failed_upload_medias:
+                continue
+
+            # store failed upload media
+            for failed_url, description in failed_upload_medias:
+                try:
+                    self.store.insert_failed_upload_media(failed_url, description)
+                except Exception as e:
+                    print(f'Insert failed. failed_url={failed_url}, description={description}',
+                          e.args, file=sys.stderr)
+                    traceback.print_exc()
+
+    def retry_backup_media(self) -> None:
+        url: str = ''
+        try:
+            for url, description in self.store.fetch_all_failed_upload_medias():
+                is_saved: bool = self.save_media(url, description)
+                if not is_saved:
+                    print(f'Retry Save failed. media_url={url}', file=sys.stderr)
+                    continue
+                self.store.delete_failed_upload_media(url)
+        except Exception as e:
+            print(f'Retry backup failed. failed_url={url}', e.args, file=sys.stderr)
+            traceback.print_exc()
+
     def crawling_tweets(self, user):
         media_tweet_dicts = self.twitter.get_target_tweets(user)
         self.backup_media(media_tweet_dicts)
+        self.retry_backup_media()
 
     def main(self):
         interval_minutes = int(Env.get_environment('INTERVAL', default='5'))

--- a/app/store.py
+++ b/app/store.py
@@ -5,6 +5,8 @@ import pytz
 import traceback
 
 from datetime import datetime
+from typing import Tuple, List
+
 from app.env import Env
 
 
@@ -41,6 +43,13 @@ class Store:
                 'VALUES (%s, %s, %s, %s)',
                 (tweet_id, user_id, tweet_date, add_date))
 
+    def insert_failed_upload_media(self, url: str, description: str) -> None:
+        with self._connection.cursor() as cursor:
+            cursor.execute(
+                'INSERT INTO failed_upload_media (url, description)'
+                'VALUES (%s, %s)',
+                (url, description))
+
     def fetch_not_added_tweets(self, tweets: list) -> list:
         with self._connection.cursor() as cursor:
             cursor.execute(
@@ -53,6 +62,19 @@ class Store:
                 (tweets,))
             return cursor.fetchall()
 
+    def fetch_all_failed_upload_medias(self) -> List[Tuple[str, str]]:
+        with self._connection.cursor() as cursor:
+            cursor.execute(
+                'SELECT url, description '
+                'FROM failed_upload_media')
+            return cursor.fetchall()
+
+    def delete_failed_upload_media(self, url: str) -> None:
+        with self._connection.cursor() as cursor:
+            cursor.execute(
+                'DELETE FROM failed_upload_media '
+                'WHERE url = %s',
+                (url,))
 
 if __name__ == '__main__':
     db = Store()

--- a/database.sql
+++ b/database.sql
@@ -8,5 +8,10 @@ create table uploaded_media_tweet
     tweet_date text not null
 );
 
-create unique index uploaded_media_tweet_tweet_id_uindex
-    on uploaded_media_tweet (tweet_id);
+create table failed_upload_media
+(
+    url         text not null
+        constraint failed_upload_media_pk
+            primary key,
+    description text not null
+);


### PR DESCRIPTION
メディアのダウンロード、またはGoogle APIによるアップロードが失敗した場合以下を実行するように変更しました。
- 失敗したメディアのURL、およびテキスト情報( `description` )をDBに保存
- backup処理終了後、失敗したメディアの再ダウンロード、再アップロード処理を追加
- この時点でまた失敗した場合は、次回の再backup処理で対処

処理が重複するため、Google Photosへのアップロード処理を関数( `save_media` )に切り出しました。