### PR TITLE
🐛 fix #31 mixed mode

### DIFF
--- a/app/twitter.py
+++ b/app/twitter.py
@@ -240,9 +240,9 @@ class Twitter:
                 if not tweet.retweeted_status:
                     continue
                 if 'mixed' in self.mode:
-                    if not hasattr(tweet, 'favorited'):
+                    if not hasattr(tweet.retweeted_status, 'favorited'):
                         continue
-                    if not tweet.favorited:
+                    if not tweet.retweeted_status.favorited:
                         continue
                 media_tweet_dict = None
                 try:

--- a/app/twitter.py
+++ b/app/twitter.py
@@ -239,9 +239,11 @@ class Twitter:
                     continue
                 if not tweet.retweeted_status:
                     continue
-                if 'mixed' in self.mode and not hasattr(tweet, 'favorited'):
-                    continue
-
+                if 'mixed' in self.mode:
+                    if not hasattr(tweet, 'favorited'):
+                        continue
+                    if not tweet.favorited:
+                        continue
                 media_tweet_dict = None
                 try:
                     media_tweet_dict = self.get_media_tweets(tweet)


### PR DESCRIPTION
`hasattr(tweet, 'favorited')`はファボした事があるかどうか、しか分かりませんでした。

よって、以前のソースではファボった後にファボを消したツイートもtargetに入っていたので
実際にファボっている状態かどうかをtarget判定に使うよう修正しました。