### PR TITLE
🐛 requiredを指定していてもエラーにならない問題を修正

### DIFF
--- a/app/env.py
+++ b/app/env.py
@@ -9,8 +9,8 @@ import termcolor
 class Env:
     @staticmethod
     def get_environment(env_name: str, default: str = '', required: bool = False) -> str:
-        env = os.environ.get(env_name, default)
-        if required and (default == '') and (env is None):
+        env: str = os.environ.get(env_name, default)
+        if required and (default == '') and (env == ''):
             sys.exit(termcolor.colored(f'Error: Please set environment "{env_name}"', 'red'))
 
         logger.debug(f'Get environment {env_name}={env}')


### PR DESCRIPTION
引数defaultのデフォルト値を `None` から `''` に変更した際にenvにNoneが返ってくるケースがなくなったためエラー終了する条件に入らなくなっていたので条件を修正しました。
https://github.com/re3turn/twicrawler/commit/fff1d2aac3fffbfa5882fc4904526e571d6be761#diff-17c8c4a8d1b69d88a4e2655da32f0526R10