### PR TITLE
🐛 公式RT先のメディアが取得できない問題を修正

### DIFF
--- a/app/twitter.py
+++ b/app/twitter.py
@@ -165,7 +165,7 @@ class Twitter:
         elif hasattr(target_tweet, 'entities') and self._has_instagram_url(target_tweet.entities):
             media_type = 'Instagram'
         else:
-            return {}
+            return tweet_medias
 
         if media_type == 'Twitter':
             extended_entities = target_tweet.extended_entities
@@ -173,9 +173,9 @@ class Twitter:
         elif media_type == 'Instagram':
             media_url_list = Instagram(self._get_instagram_url(target_tweet.entities)).get_media_urls()
         else:
-            return {}
+            return tweet_medias
 
-        tweet_medias = {target_tweet.id_str: TweetMedia(urls=media_url_list, tweet=target_tweet)}
+        tweet_medias[target_tweet.id_str] = TweetMedia(urls=media_url_list, tweet=target_tweet)
 
         return tweet_medias
 


### PR DESCRIPTION
公式RT先のメディアがあっても、元のツイートにメディアが存在しない場合、空の辞書を返してしまっていたため、取得した辞書( `tweet_medias` )を返す様に修正した。
また、元のツイートにメディアが存在していた場合も辞書( `tweet_medias` )を上書きしてしまっていたので、追加するように修正した。