### PR TITLE
🐛 Fix #45 コネクションが閉じていた場合再接続するように変更

### DIFF
--- a/app/store.py
+++ b/app/store.py
@@ -10,6 +10,8 @@ from app.env import Env
 from app.log import Log
 from app.tz import Tz
 
+MAX_CONNECTION_RETRY = 3
+
 
 class Store:
     def __init__(self) -> None:
@@ -30,15 +32,25 @@ class Store:
         connection.autocommit = True
         return connection
 
+    def _execute_query(self, query: str, variables: Optional[Tuple[Any, ...]] = None) -> psycopg2.extensions.cursor:
+        for i in range(MAX_CONNECTION_RETRY + 1):
+            try:
+                with self._connection.cursor() as cursor:
+                    cursor.execute(query, variables)
+                    return cursor
+            except psycopg2.InterfaceError as e:
+                if i == MAX_CONNECTION_RETRY:
+                    raise e
+                logger.warning(f'Reconnection. exception={e.args}')
+                self._connection = self._get_connection()
+
     def insert_tweet_info(self, tweet_id: str, user_id: str, tweet_date: str) -> None:
         logger.debug(f'Insert tweet_id={tweet_id}, user_id={user_id}, and tweet_date={tweet_date} '
                      f'into failed_upload_media table.')
         add_date: str = datetime.now(self._tz).strftime('%Y-%m-%d %H:%M:%S')
-        with self._connection.cursor() as cursor:
-            cursor.execute(
-                'INSERT INTO uploaded_media_tweet (tweet_id, user_id, tweet_date, add_date)'
-                'VALUES (%s, %s, %s, %s)',
-                (tweet_id, user_id, tweet_date, add_date))
+        query: str = 'INSERT INTO uploaded_media_tweet (tweet_id, user_id, tweet_date, add_date) ' \
+                     'VALUES (%s, %s, %s, %s)'
+        self._execute_query(query=query, variables=(tweet_id, user_id, tweet_date, add_date))
 
     def insert_failed_upload_media(self, url: str, description: str, user_id: str) -> None:
         logger.debug(f'Insert url={url}, description={description} and user_id={user_id} '
@@ -51,32 +63,27 @@ class Store:
 
     def fetch_not_added_tweets(self, tweets: List[str]) -> List[str]:
         logger.debug('Fetch not added tweets from uploaded_media_tweet table.')
-        with self._connection.cursor() as cursor:
-            cursor.execute(
-                'SELECT T2.tweet_id '
-                'FROM uploaded_media_tweet T1 '
-                'RIGHT OUTER JOIN'
-                '  (SELECT unnest(%s) as tweet_id) T2 '
-                'ON T1.tweet_id = T2.tweet_id '
-                'WHERE T1.tweet_id is null',
-                (tweets,))
-            return cursor.fetchall()
+        query: str = 'SELECT T2.tweet_id ' \
+                     'FROM uploaded_media_tweet T1 ' \
+                     'RIGHT OUTER JOIN' \
+                     '  (SELECT unnest(%s) as tweet_id) T2 ' \
+                     'ON T1.tweet_id = T2.tweet_id ' \
+                     'WHERE T1.tweet_id is null'
+        cursor: psycopg2.extensions.cursor = self._execute_query(query=query, variables=(tweets,))
+        return cursor.fetchall()
 
     def fetch_all_failed_upload_medias(self) -> List[Tuple[str, str, str]]:
         logger.debug('Fetch url and description from failed_upload_media table.')
-        with self._connection.cursor() as cursor:
-            cursor.execute(
-                'SELECT url, description, user_id '
-                'FROM failed_upload_media')
-            return cursor.fetchall()
+        query: str = 'SELECT url, description, user_id ' \
+                     'FROM failed_upload_media'
+        cursor: psycopg2.extensions.cursor = self._execute_query(query=query)
+        return cursor.fetchall()
 
     def delete_failed_upload_media(self, url: str) -> None:
         logger.debug(f'Delete row url={url} from failed_upload_media table.')
-        with self._connection.cursor() as cursor:
-            cursor.execute(
-                'DELETE FROM failed_upload_media '
-                'WHERE url = %s',
-                (url,))
+        query: str = 'DELETE FROM failed_upload_media ' \
+                     'WHERE url = %s'
+        self._execute_query(query=query, variables=(url,))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
execute()実行時にコネクションが閉じていた場合、最大3回までコネクションを再接続するように変更した。
