### PR TITLE
コネクションが閉じた場合に再接続する方式をやめて毎回接続し直すように変更

### DIFF
--- a/app/store.py
+++ b/app/store.py
@@ -4,7 +4,7 @@ import logging
 import psycopg2
 
 from datetime import datetime
-from typing import Tuple, List, Optional, Any
+from typing import Tuple, List
 
 from app.env import Env
 from app.log import Log
@@ -17,36 +17,19 @@ class Store:
     def __init__(self) -> None:
         self._db_url: str = Env.get_environment('DATABASE_URL', required=True)
         self._sslmode: str = Env.get_environment('DATABASE_SSLMODE', default='require', required=False)
-        self._connection: Any = self._get_connection()
         self._tz = Tz.timezone()
 
         logger.debug(f'Store setting info. _db_url={self._db_url}, _sslmode={self._sslmode}')
 
-    def _get_connection(self) -> Optional[psycopg2.extensions.connection]:
+    def _get_connection(self) -> psycopg2.extensions.connection:
         try:
             connection = psycopg2.connect(self._db_url, sslmode=self._sslmode)
         except Exception as e:
             logger.exception(f'Connection error. exception={e.args}')
-            return None
+            raise
 
         connection.autocommit = True
         return connection
-
-    def _execute_query(self, query: str,
-                       variables: Optional[Tuple[Any, ...]] = None) -> Optional[List[Tuple[Any, ...]]]:
-        for i in range(MAX_CONNECTION_RETRY + 1):
-            try:
-                with self._connection.cursor() as cursor:
-                    cursor.execute(query, variables)
-                    return cursor.fetchall()
-            except psycopg2.InterfaceError as e:
-                if i == MAX_CONNECTION_RETRY:
-                    raise e
-                logger.warning(f'Reconnection. exception={e.args}')
-                self._connection = self._get_connection()
-            except psycopg2.ProgrammingError:
-                #  Not produce any result set
-                return None
 
     def insert_tweet_info(self, tweet_id: str, user_id: str, tweet_date: str) -> None:
         logger.debug(f'Insert tweet_id={tweet_id}, user_id={user_id}, and tweet_date={tweet_date} '
@@ -54,16 +37,18 @@ class Store:
         add_date: str = datetime.now(self._tz).strftime('%Y-%m-%d %H:%M:%S')
         query: str = 'INSERT INTO uploaded_media_tweet (tweet_id, user_id, tweet_date, add_date) ' \
                      'VALUES (%s, %s, %s, %s)'
-        self._execute_query(query=query, variables=(tweet_id, user_id, tweet_date, add_date))
+        with self._get_connection() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(query=query, vars=(tweet_id, user_id, tweet_date, add_date))
 
     def insert_failed_upload_media(self, url: str, description: str, user_id: str) -> None:
         logger.debug(f'Insert url={url}, description={description} and user_id={user_id} '
                      f'into failed_upload_media table.')
-        with self._connection.cursor() as cursor:
-            cursor.execute(
-                'INSERT INTO failed_upload_media (url, description, user_id)'
-                'VALUES (%s, %s, %s)',
-                (url, description, user_id))
+        query: str = 'INSERT INTO failed_upload_media (url, description, user_id) ' \
+                     'VALUES (%s, %s, %s)'
+        with self._get_connection() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(query=query, vars=(url, description, user_id))
 
     def fetch_not_added_tweets(self, tweets: List[str]) -> List[Tuple[str]]:
         logger.debug('Fetch not added tweets from uploaded_media_tweet table.')
@@ -73,19 +58,27 @@ class Store:
                      '  (SELECT unnest(%s) as tweet_id) T2 ' \
                      'ON T1.tweet_id = T2.tweet_id ' \
                      'WHERE T1.tweet_id is null'
-        return self._execute_query(query=query, variables=(tweets,))
+        with self._get_connection() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(query=query, vars=(tweets,))
+                return cursor.fetchall()
 
     def fetch_all_failed_upload_medias(self) -> List[Tuple[str, str, str]]:
         logger.debug('Fetch url and description from failed_upload_media table.')
         query: str = 'SELECT url, description, user_id ' \
                      'FROM failed_upload_media'
-        return self._execute_query(query=query)
+        with self._get_connection() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(query=query)
+                return cursor.fetchall()
 
     def delete_failed_upload_media(self, url: str) -> None:
         logger.debug(f'Delete row url={url} from failed_upload_media table.')
         query: str = 'DELETE FROM failed_upload_media ' \
                      'WHERE url = %s'
-        self._execute_query(query=query, variables=(url,))
+        with self._get_connection() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(query=query, vars=(url,))
 
 
 if __name__ == '__main__':

--- a/app/store.py
+++ b/app/store.py
@@ -10,8 +10,6 @@ from app.env import Env
 from app.log import Log
 from app.tz import Tz
 
-MAX_CONNECTION_RETRY = 3
-
 
 class Store:
     def __init__(self) -> None:


### PR DESCRIPTION
#46 で修正したコネクションが閉じた場合に再接続する方式をやめて
75a2b6f5c4546266ce0946a22650153b30cd8f88 以前に採用していた毎回接続し直す方式に戻した。

また、`connection()` に失敗した場合は、DBの更新も取得もできないため例外を上げるように変更した。