### PR TITLE
Fix #63 User-Agentを指定しないとInstagramのページを取得できない

### DIFF
--- a/app/google_photos.py
+++ b/app/google_photos.py
@@ -114,7 +114,7 @@ class GooglePhotos:
             return ''
 
     def _fetch_albums(self, page_token: str) -> dict:
-        logger.debug(f'Execute "service.albums().list()" to fetch albums list in Google Photos.')
+        logger.debug('Execute "service.albums().list()" to fetch albums list in Google Photos.')
         params: Dict[str, Union[int, str, bool]] = {
             'pageSize': 50,
             'pageToken': page_token,

--- a/app/instagram.py
+++ b/app/instagram.py
@@ -21,7 +21,7 @@ class Instagram:
 
         pattern = re.compile('window._sharedData = ({.*?});')
         script = html.find('script', text=pattern)
-        data = pattern.search(script.text).group(1)  # type: ignore
+        data = pattern.search(script.string).group(1)  # type: ignore
         json_user_data = json.loads(data)
 
         return json_user_data

--- a/app/instagram.py
+++ b/app/instagram.py
@@ -14,9 +14,12 @@ from app.log import Log
 class Instagram:
     def __init__(self, url: str) -> None:
         self.url = url
+        self.headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6)'
+                                      'AppleWebKit/537.36 (KHTML, like Gecko)'
+                                      'Chrome/85.0.4183.102'}
 
     def _get_json_data(self) -> dict:
-        res = requests.get(self.url)
+        res = requests.get(self.url, headers=self.headers)
         html = BeautifulSoup(res.content, 'html.parser')
 
         pattern = re.compile('window._sharedData = ({.*?});')

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,21 +1,21 @@
-import httplib2
 import logging
-import nose2.tools
 import os
-import tweepy
 import urllib.error
-
-from googleapiclient.errors import HttpError
-from testfixtures import LogCapture
 from typing import Dict, Tuple, List, Optional
 from unittest import mock
+
+import httplib2
+import nose2.tools
+import tweepy
+from googleapiclient.errors import HttpError
+from testfixtures import LogCapture
 
 from app.crawler import Crawler
 from app.google_photos import GooglePhotos
 from app.store import Store
 from app.twitter import Twitter, TweetMedia, TwitterUser
-from tests.test_twitter import TwitterTestUtils
 from tests.lib.utils import delete_env, load_json
+from tests.test_twitter import TwitterTestUtils
 
 TEST_TWITTER_ID = 'TwicrawlerT'
 TEST_USER_ID = 'test_user_id'
@@ -201,8 +201,8 @@ class TestCrawler:
 
     @mock.patch('time.sleep', mock_sleep)  # for retry
     def test_save_media__download_failed(self) -> None:
-        mock_request.urlretrieve.side_effect = urllib.error.HTTPError(TEST_MEDIA_URL, code='500', msg='', hdrs='',
-                                                                      fp=None)
+        mock_request.urlretrieve.side_effect = urllib.error.HTTPError(TEST_MEDIA_URL, code=500, msg='', hdrs={},
+                                                                      fp=None)  # type: ignore
 
         with LogCapture(level=logging.ERROR) as log:
             is_save = self.crawler.save_media(TEST_MEDIA_URL, TEST_DESCRIPTION, TEST_USER_ID)

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -215,7 +215,7 @@ class TestCrawler:
 
         with LogCapture(level=logging.ERROR) as log:
             is_save = self.crawler.save_media(TEST_MEDIA_URL, TEST_DESCRIPTION, TEST_USER_ID)
-            log.check(('app.crawler', 'ERROR', f'Error reason='),
+            log.check(('app.crawler', 'ERROR', 'Error reason='),
                       ('app.crawler', 'ERROR', f'upload failed. media_url={TEST_MEDIA_URL}'))
         assert is_save is False
 


### PR DESCRIPTION
- `request.get()` 時に User-Agentを追加
- テスト時のみ取得したHTMLタグの文字列を `script.text` で取得できなかったため通常時も `script.string` に変更