### PR TITLE
セットアップ・実行手順をREADMEに追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN apk add --no-cache --virtual build-deps build-base libffi-dev \
   && pip install --no-cache-dir -r requirements.txt \
   && apk del build-deps
 
-COPY app .
+COPY app ./app
 COPY run.py .
+COPY get_refresh_token.py .
 
 CMD ["python", "./run.py"]

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ cd twicrawler
 
 ## Setup
 
-Setting [environment variable](#Environment variable) in the `.env` file.
+Setting [environment variable](#environment-variable) in the `.env` file.
 
 If you need examples, check the sample `.env.sample` in this repository.
 
 ### Get Google refresh token
 
-Setting [environment variable](#Environment variable) `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` to `.env` file.
+Setting [environment variable](#environment-variable) `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` to `.env` file.
 
 ```
 docker-compose build app

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ cd twicrawler
 
 Setting [environment variable](#environment-variable) in the `.env` file.
 
-If you need examples, check the sample `.env.sample` in this repository.
+If you need examples, check the sample [`.env.sample`](.env.sample) in this repository.
 
 ### Get Google refresh token
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,46 @@
 # Installation
 
 ## Requirement
- - python3.7.*
- - PostgreSQL
- - Twitter APIs
- - Google APIs
+- Docker version 18.06.0+
+- docker-compose version 1.22.0+
+- Twitter APIs
+- Google APIs
 
 ## Install
 
 ```:bash
 git clone https://github.com/re3turn/twicrawler.git
 cd twicrawler
-pip3 install -r requirements.txt
 ```
 
-## Get Google refresh token
+## Setup
 
-Execute `get_refresh_token.py` after setting environment variables `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`.
+Setting [environment variable](#Environment variable) in the `.env` file.
+
+If you need examples, check the sample `.env.sample` in this repository.
+
+### Get Google refresh token
+
+Setting [environment variable](#Environment variable) `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` to `.env` file.
+
+```
+docker-compose build app
+docker run -i --env-file=.env twicrawler python get_refresh_token.py
+```
+
+#### Execution example
 
 ```:bash
-$ python3 get_refresh_token.py
+$ docker run -i --env-file=.env twicrawler python get_refresh_token.py
 Please visit this URL to authorize this application: https://accounts.google.com/o/oauth2/auth?response_type=code&.....
 Enter the authorization code: {AUTHORIZATION CODE}
 refresh_token: {REFRESH TOKEN}
+```
+
+## Run
+
+```:bash
+docker-compose up -d
 ```
 
 # Environment variable 


### PR DESCRIPTION
#39
- セットアップと実行方法をREADMEに追加
- ローカルのPythonを使用する手順を削除し、Dockerで実行する方法のみを記載
- `get_refresh_token.py` をコンテナ内に含めるようにDockerfileを修正

Dockerとdocker-composeのバージョンについては以下を参照

- https://docs.docker.com/compose/compose-file/compose-file-v3/
- https://github.com/docker/compose/releases/tag/1.22.0