### PR TITLE
Fix #66 #67 新規のdocker-compose up が失敗する

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
 name: Tests
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - '**.py'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.4-alpine3.10
+FROM python:3.7-alpine
 
 WORKDIR /app
 COPY requirements.txt .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4>=4.8.2
 dataclasses_json
 flake8
-google-api-python-client
+google-api-python-client==1.12.8
 google-auth-httplib2
 google-auth-oauthlib
 google-oauth

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ requests
 retry
 termcolor
 testfixtures
-tweepy>=3.8.0
+tweepy==3.10.0


### PR DESCRIPTION
#68 #67

- 古いイメージだとバージョンを指定していないPythonライブラリに必要なものが入っていないようなのでpython 3.7系の最新イメージを使用するように変更
- google-api-python-client の関数仕様がv2で変わっているのでv1の最終バージョンに固定
- tweepy v4で `tweepy.Status` が `tweepy.models.Status` に移動しているのでv3の最終バージョンに固定