### PR TITLE
postgresのバージョンを13.xに固定

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
       - postgres
     restart: always
   postgres:
-    image: postgres
+    image: postgres:13
     ports:
       - 5432:5432
     volumes:


### PR DESCRIPTION
postgresの最新バージョンは14だが、psycopg2が13までしか対応していないためpostgresを13.xに固定する

なお、psycopg3はpostgres 14に対応している模様
https://www.postgresql.org/about/news/psycopg-30-released-2328/